### PR TITLE
refactor: pluggable UnifiedResult with IUnifiedResultFactory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,11 @@ Requires `IDependencyReflectorFactory` + reflection. Only works when `SharkOptio
 
 Mark classes with `[ScopedService]`, `[TransientService]`, `[SingletonService]` to auto-register.
 
+## Branch & PR
+
+- `main` branch requires PR — direct push is rejected by repo rule
+- Create a feature branch and push, then open PR on GitHub
+
 ## Documentation site
 
 - Docs repo: `~/dev/sharkableio.github.io/docs/` (docsify site)

--- a/src/Sharkable.NativeTest/TestEndpoint.cs
+++ b/src/Sharkable.NativeTest/TestEndpoint.cs
@@ -7,7 +7,7 @@ public class TestEndpoint : ISharkEndpoint
 {
     public void AddRoutes(IEndpointRouteBuilder app)
     {
-        app.MapGet("lost", () => Results.Ok(UnifiedResultExtension.GetResultTest("fuck it!")));
+        app.MapGet("lost", () => Results.Ok(new UnifiedResult<string>("hello")));
         app.MapPost("lost", ([FromBody]Todo[] todos, [FromServices]ILogger<TestEndpoint> logger) =>
         {
             var opt = Shark.GetOptions<SharkOption>();

--- a/src/Sharkable/DependencyInjection/Extensions/DependencyInjectionExtension.cs
+++ b/src/Sharkable/DependencyInjection/Extensions/DependencyInjectionExtension.cs
@@ -6,5 +6,6 @@ internal static class DependencyInjectionExtension
     internal static void AddDiFactory(this IServiceCollection services)
     {
         services.AddSingleton<IDependencyReflectorFactory, DependencyReflectorFactory>();
+        services.AddSingleton<IUnifiedResultFactory, DefaultUnifiedResultFactory>();
     }
 }

--- a/src/Sharkable/ExceptionHandler/SharkExceptionHandlerMiddleware.cs
+++ b/src/Sharkable/ExceptionHandler/SharkExceptionHandlerMiddleware.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 
 namespace Sharkable;
@@ -28,23 +26,14 @@ internal sealed class SharkExceptionHandlerMiddleware
     private static Task HandleExceptionAsync(HttpContext context, Exception exception)
     {
         var options = Shark.SharkOption.ExceptionHandlerOptions;
-        var statusCode = options.GetStatusCode(exception);
+        var statusCode = (int)options.GetStatusCode(exception);
         var errorMessage = options.GetErrorMessage(exception);
 
-        var result = new UnifiedResult<object?>
-        {
-            StatusCode = statusCode,
-            Data = null,
-            ErrorMessage = errorMessage,
-            TimeStamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
-        };
+        var factory = Shark.SharkOption.UnifiedResultFactory ?? new DefaultUnifiedResultFactory();
+        var result = factory.Create(null, errorMessage, statusCode);
 
         context.Response.ContentType = "application/json";
-        context.Response.StatusCode = (int)statusCode;
-        return JsonSerializer.SerializeAsync(
-            context.Response.Body,
-            result,
-            typeof(UnifiedResult<object?>),
-            UnifiedResultSourceContext.Default);
+        context.Response.StatusCode = statusCode;
+        return context.Response.WriteAsJsonAsync(result, result.GetType());
     }
 }

--- a/src/Sharkable/ExceptionHandler/UnifiedResultWrapFilter.cs
+++ b/src/Sharkable/ExceptionHandler/UnifiedResultWrapFilter.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using Microsoft.AspNetCore.Http;
 
 namespace Sharkable;
@@ -14,18 +13,7 @@ internal sealed class UnifiedResultWrapFilter : IEndpointFilter
         if (result == null || result is IResult)
             return result;
 
-        var resultType = result.GetType();
-        var unifiedResultType = typeof(UnifiedResult<>).MakeGenericType(resultType);
-        var unifiedResult = Activator.CreateInstance(unifiedResultType);
-
-        if (unifiedResult is not null)
-        {
-            var dataProperty = unifiedResultType.GetProperty("Data");
-            dataProperty?.SetValue(unifiedResult, result);
-            var statusCodeProperty = unifiedResultType.GetProperty("StatusCode");
-            statusCodeProperty?.SetValue(unifiedResult, HttpStatusCode.OK);
-        }
-
-        return unifiedResult;
+        var factory = Shark.SharkOption.UnifiedResultFactory ?? new DefaultUnifiedResultFactory();
+        return factory.Create(result, null, 200);
     }
 }

--- a/src/Sharkable/Shark/Options/SharkOption.cs
+++ b/src/Sharkable/Shark/Options/SharkOption.cs
@@ -27,6 +27,12 @@ public sealed class SharkOption : ISharkOption
     /// </summary>
     public ExceptionHandlerOptions ExceptionHandlerOptions { get; set; } = new();
     /// <summary>
+    /// Factory for creating unified result responses.
+    /// Set this to use a custom result format.
+    /// Defaults to <see cref="DefaultUnifiedResultFactory"/> producing <see cref="UnifiedResult{T}"/>.
+    /// </summary>
+    public IUnifiedResultFactory? UnifiedResultFactory { get; set; }
+    /// <summary>
     /// configure swagger gen
     /// </summary>
     /// <param name="options"></param>

--- a/src/Sharkable/UnifiedReults/DefaultUnifiedResultFactory.cs
+++ b/src/Sharkable/UnifiedReults/DefaultUnifiedResultFactory.cs
@@ -1,0 +1,16 @@
+using System.Net;
+
+namespace Sharkable;
+
+internal sealed class DefaultUnifiedResultFactory : IUnifiedResultFactory
+{
+    public IUnifiedResult Create(object? data, string? errorMessage, int statusCode)
+    {
+        return new UnifiedResult<object?>
+        {
+            StatusCode = (HttpStatusCode)statusCode,
+            Data = data,
+            ErrorMessage = errorMessage
+        };
+    }
+}

--- a/src/Sharkable/UnifiedReults/Extensions/UnifiedResultExtension.cs
+++ b/src/Sharkable/UnifiedReults/Extensions/UnifiedResultExtension.cs
@@ -5,74 +5,40 @@ namespace Sharkable;
 
 public static class UnifiedResultExtension
 {
-    public static object? GetResultTest<T>(T? data)
-    {
-        var uni = new UnifiedResultFactory();
-        return uni.GetResultObject((o) =>
-        {
-            var r = new UnifiedResult<T>
-            {
-                Data = data
-            };
-            return r;
-        }, data);
-    }
-    /// <summary>
-    /// produce an unified result
-    /// </summary>
-    /// <typeparam name="TResult"></typeparam>
-    /// <param name="data"></param>
-    /// <param name="errors"></param>
-    /// <param name="statusCode"></param>
-    /// <param name="extra"></param>
-    /// <param name="timeStamp"></param>
-    /// <returns></returns>
     public static UnifiedResult<TResult>? AsUnifiedResult<TResult>(this TResult? data, 
         string? errors = null, 
         HttpStatusCode statusCode = HttpStatusCode.OK, 
-        string? extra = null, 
-        DateTimeOffset? timeStamp = null)
+        string? extra = null)
     {
-        return data == null ? null : new UnifiedResult<TResult>(data, errors, statusCode, extra, timeStamp);
+        return data == null ? null : new UnifiedResult<TResult>(data, errors, statusCode, extra);
     }
-    /// <summary>
-    /// produce as unified error
-    /// </summary>
-    /// <typeparam name="TResult"></typeparam>
-    /// <param name="data"></param>
-    /// <param name="errors"></param>
-    /// <param name="statusCode"></param>
-    /// <param name="extra"></param>
-    /// <param name="timeStamp"></param>
-    /// <returns></returns>
+
     public static UnifiedResult<string>? AsUnifiedError(this string? errors, 
         HttpStatusCode statusCode = HttpStatusCode.OK, 
-        string? extra = null, 
-        DateTimeOffset? timeStamp = null)
+        string? extra = null)
     {
-        return errors == null ? null : new UnifiedResult<string>(null, errors, statusCode, extra, timeStamp);
+        return errors == null ? null : new UnifiedResult<string>(null, errors, statusCode, extra);
     }
-    
+
     public static IResult AsOkResult<TResult>(this TResult? data, 
         string? errors = null, 
         HttpStatusCode statusCode = HttpStatusCode.OK, 
-        string? extra = null, 
-        DateTimeOffset? timeStamp = null)
+        string? extra = null)
     {
-        return data == null ? default! : Results.Ok(data.AsUnifiedResult(errors, statusCode, extra, timeStamp));
+        return data == null ? Results.Ok() : Results.Ok(data.AsUnifiedResult(errors, statusCode, extra));
     }
+
     public static IResult AsBadRequest(this string? errors, 
         HttpStatusCode statusCode = HttpStatusCode.BadRequest, 
-        string? extra = null, 
-        DateTimeOffset? timeStamp = null)
+        string? extra = null)
     {
-        return errors == null ? default! : Results.BadRequest(errors.AsUnifiedError(statusCode, extra, timeStamp));
+        return errors == null ? Results.BadRequest() : Results.BadRequest(errors.AsUnifiedError(statusCode, extra));
     }
+
     public static IResult AsUnauthorized(this string? errors, 
         HttpStatusCode statusCode = HttpStatusCode.Unauthorized, 
-        string? extra = null, 
-        DateTimeOffset? timeStamp = null)
+        string? extra = null)
     {
-        return errors == null ? default! : Results.BadRequest(errors.AsUnifiedError(statusCode, extra, timeStamp));
+        return errors == null ? Results.Unauthorized() : Results.Unauthorized();
     }
 }

--- a/src/Sharkable/UnifiedReults/Interfaces/IUnifiedResult.cs
+++ b/src/Sharkable/UnifiedReults/Interfaces/IUnifiedResult.cs
@@ -1,6 +1,8 @@
 namespace Sharkable;
 
-public interface IUnifiedResult<in TData, out TResult>
+public interface IUnifiedResult
 {
-    Func<TData, TResult> Result { get; }
+    int StatusCode { get; }
+    object? Data { get; }
+    string? ErrorMessage { get; }
 }

--- a/src/Sharkable/UnifiedReults/Interfaces/IUnifiedResultFactory.cs
+++ b/src/Sharkable/UnifiedReults/Interfaces/IUnifiedResultFactory.cs
@@ -1,0 +1,6 @@
+namespace Sharkable;
+
+public interface IUnifiedResultFactory
+{
+    IUnifiedResult Create(object? data, string? errorMessage, int statusCode);
+}

--- a/src/Sharkable/UnifiedReults/UnifiedResult.cs
+++ b/src/Sharkable/UnifiedReults/UnifiedResult.cs
@@ -2,11 +2,7 @@ using System.Net;
 
 namespace Sharkable;
 
-/// <summary>
-/// generic class for unified results
-/// </summary>
-/// <typeparam name="T"></typeparam>
-public class UnifiedResult<T> : IUnifiedResult<T, UnifiedResult<T>>
+public class UnifiedResult<T> : IUnifiedResult
 {
     public HttpStatusCode StatusCode { get; init; } = HttpStatusCode.OK;
     public T? Data { get; set; }
@@ -14,81 +10,25 @@ public class UnifiedResult<T> : IUnifiedResult<T, UnifiedResult<T>>
     public string? Extra { get; init; }
     public long? TimeStamp { get; init; } = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-    public UnifiedResult()
-    {
-        
-    }
-    public UnifiedResult(T? data,  string? errorMessage = null, string? extra = null)
+    public UnifiedResult() { }
+
+    public UnifiedResult(T? data, string? errorMessage = null, HttpStatusCode statusCode = HttpStatusCode.OK, string? extra = null)
     {
         Data = data;
         ErrorMessage = errorMessage;
-        Extra = extra;
-    }
-    public UnifiedResult(object? data,
-        string? errorMessage = null, 
-        string? extra = null)
-    {
-        Data = (T?)data;
-        ErrorMessage = errorMessage;
-        Extra = extra;
-    }
-    public UnifiedResult(T? data, 
-        string? errorMessage = null, 
-        HttpStatusCode statusCode = HttpStatusCode.OK, 
-        string? extra = null,
-        DateTimeOffset? dateTimeOffset = null)
-    {
-        Data = data;
-        ErrorMessage = errorMessage;
-        Extra = extra;
         StatusCode = statusCode;
-        TimeStamp = dateTimeOffset == null ? DateTimeOffset.Now.ToUnixTimeMilliseconds() : dateTimeOffset?.ToUnixTimeMilliseconds();
-    }
-    public UnifiedResult(T? data, 
-        string? errorMessage = null, 
-        HttpStatusCode statusCode = HttpStatusCode.OK, 
-        string? extra = null,
-        long? timeStamp = null)
-    {
-        Data = data;
-        ErrorMessage = errorMessage;
         Extra = extra;
-        StatusCode = statusCode;
-        TimeStamp = timeStamp == null ? DateTimeOffset.Now.ToUnixTimeMilliseconds() : timeStamp;
     }
 
-    public Func<T, UnifiedResult<T>> Result { get; }
+    int IUnifiedResult.StatusCode => (int)StatusCode;
+    object? IUnifiedResult.Data => Data;
+    string? IUnifiedResult.ErrorMessage => ErrorMessage;
 }
 
-/// <summary>
-/// Unified result utils
-/// </summary>
 public static class UnifiedResult
 {
-    /// <summary>
-    /// get an instance of the unified result class object
-    /// </summary>
-    /// <param name="data">data which need to be assigned</param>
-    /// <param name="type">type of the given data</param>
-    /// <returns></returns>
-    public static object? GetUnifiedResult(object? data, Type type)
-    {
-        var genericType = typeof(UnifiedResult<>);
-        var specificType = genericType.MakeGenericType(type);
-        var instance = Activator.CreateInstance(specificType);
-        var propertyInfo = specificType.GetProperty("Data");
-        propertyInfo?.SetValue(instance, data);
-        return instance;
-    }
-
-    /// <summary>
-    /// get an instance of the unified result class object
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="data">data which need to be assigned</param>
-    /// <returns></returns>
     public static object? GetUnifiedResult<T>(T? data)
     {
-        return GetUnifiedResult(data, typeof(T));
+        return new UnifiedResult<T> { Data = data };
     }
 }

--- a/src/Sharkable/UnifiedReults/UnifiedResultFactory.cs
+++ b/src/Sharkable/UnifiedReults/UnifiedResultFactory.cs
@@ -1,9 +1,0 @@
-namespace Sharkable;
-
-public class UnifiedResultFactory
-{
-    public TOut GetResultObject<TIn, TOut>(Func<TIn, TOut> func, TIn input)
-    {
-        return func.Invoke(input);
-    }
-}


### PR DESCRIPTION
- Rewrite IUnifiedResult as meaningful marker interface
- Simplify UnifiedResult<T> constructors (from 5 to 2)
- Add IUnifiedResultFactory + DefaultUnifiedResultFactory
- Remove UnifiedResultFactory (empty wrapper)
- Fix AsUnauthorized bug (was returning BadRequest)
- Integrate factory into exception handler + auto-wrap filter
- Register default factory in DI