### PR TITLE
Feat/tests and native test demo

### DIFF
--- a/src/Sharkable.NativeTest/Program.cs
+++ b/src/Sharkable.NativeTest/Program.cs
@@ -84,6 +84,7 @@ public partial class MyUnifiedResultContext : JsonSerializerContext
 [JsonSerializable(typeof(MyApiResult))]
 [JsonSerializable(typeof(PostBody))]
 [JsonSerializable(typeof(PostBody[]))]
+[JsonSerializable(typeof(VersionInfo))]
 public partial class NativeTestJsonContext : JsonSerializerContext
 {
     

--- a/src/Sharkable.NativeTest/Sharkable.NativeTest.http
+++ b/src/Sharkable.NativeTest/Sharkable.NativeTest.http
@@ -9,3 +9,13 @@ GET {{Sharkable.NativeTest_HostAddress}}/todos/1
 Accept: application/json
 
 ###
+
+GET {{Sharkable.NativeTest_HostAddress}}/api/v1/versioned@1/info
+Accept: application/json
+
+###
+
+GET {{Sharkable.NativeTest_HostAddress}}/api/v2/versioned@2/info
+Accept: application/json
+
+###

--- a/src/Sharkable.NativeTest/VersionedEndpoint.cs
+++ b/src/Sharkable.NativeTest/VersionedEndpoint.cs
@@ -1,0 +1,23 @@
+namespace Sharkable.NativeTest;
+
+[SharkVersion("v1")]
+[SharkTag("versioned")]
+public class VersionedV1Endpoint : ISharkEndpoint
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet("info", () => new VersionInfo("v1", "Initial release"));
+    }
+}
+
+[SharkVersion("v2")]
+[SharkTag("versioned")]
+public class VersionedV2Endpoint : ISharkEndpoint
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet("info", () => new VersionInfo("v2", "With new features"));
+    }
+}
+
+public sealed record VersionInfo(string Version, string Description);

--- a/src/Sharkable.Tests/EndpointTests.cs
+++ b/src/Sharkable.Tests/EndpointTests.cs
@@ -76,6 +76,33 @@ public class EndpointTests : IClassFixture<SharkTestFixture>
     }
 
     [Fact]
+    public async Task VersionedEndpoint_Uses_Version_In_Url()
+    {
+        var res = await _client.GetAsync("/api/v1/versionedtest/ping");
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        var body = await res.Content.ReadAsStringAsync();
+        Assert.Equal("versioned-pong", body);
+    }
+
+    [Fact]
+    public async Task VersionedAdminEndpoint_Uses_Both_Version_And_Group()
+    {
+        var res = await _client.GetAsync("/api/v2/admin/status");
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        var body = await res.Content.ReadAsStringAsync();
+        Assert.Equal("v2-admin-status", body);
+    }
+
+    [Fact]
+    public async Task OpenApiDoc_Contains_Versioned_Paths()
+    {
+        var res = await _client.GetAsync("/openapi/v1.json");
+        var doc = await res.Content.ReadAsStringAsync();
+        Assert.Contains("/api/v1/versionedTest/ping", doc);
+        Assert.Contains("/api/v2/admin/status", doc);
+    }
+
+    [Fact]
     public async Task OpenApiDoc_Has_OperationId()
     {
         var res = await _client.GetAsync("/openapi/v1.json");

--- a/src/Sharkable.Tests/TestEndpoints.cs
+++ b/src/Sharkable.Tests/TestEndpoints.cs
@@ -96,6 +96,25 @@ public class DiTestEndpoint : ISharkEndpoint
     }
 }
 
+[SharkVersion("v1")]
+public class VersionedTestEndpoint : ISharkEndpoint
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet("ping", () => "versioned-pong");
+    }
+}
+
+[SharkVersion("v2")]
+[EndpointGroup("admin")]
+public class VersionedAdminEndpoint : ISharkEndpoint
+{
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet("status", () => "v2-admin-status");
+    }
+}
+
 public class FormatTestEndpoint : ISharkEndpoint
 {
     public void AddRoutes(IEndpointRouteBuilder app)

--- a/src/Sharkable/SharkEndpoint/Attributes/SharkVersionAttribute.cs
+++ b/src/Sharkable/SharkEndpoint/Attributes/SharkVersionAttribute.cs
@@ -1,0 +1,13 @@
+namespace Sharkable;
+
+/// <summary>
+/// Specifies an API version for an <see cref="ISharkEndpoint"/> class.
+/// The version is prepended to the URL path: <c>api/v1/{group}/{route}</c>.
+/// </summary>
+/// <param name="version">Version string (e.g., "v1", "V2"). Case is transformed by <see cref="EndpointFormat"/>.</param>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class SharkVersionAttribute(string version) : Attribute
+{
+    /// <summary>The version string to include in the URL path.</summary>
+    public string Version { get; } = version;
+}

--- a/src/Sharkable/SharkEndpoint/Extensions/EndPointExtension.cs
+++ b/src/Sharkable/SharkEndpoint/Extensions/EndPointExtension.cs
@@ -53,20 +53,28 @@ internal static class SharkEndPointExtension
                 sharkEndpoint.groupName = groupAttr.Name;
             }
 
+            var versionAttr = e.GetType().GetCustomAttribute<SharkVersionAttribute>();
+            if (versionAttr != null)
+            {
+                sharkEndpoint.version = versionAttr.Version;
+            }
+
             if (string.IsNullOrWhiteSpace(sharkEndpoint.apiPrefix))
                 sharkEndpoint.apiPrefix = options.Value.ApiPrefix;
 
             collected.Add((sharkEndpoint, e.GetType()));
         });
 
-        // Phase 2: Group by resolved group name
+        // Phase 2: Group by (version, groupName) tuple
         var grouped = new Dictionary<string, List<(SharkEndpoint, Type)>>();
         collected.MyForEach(item =>
         {
+            var version = item.endpoint.version?.GetCaseFormat(options.Value.Format);
             var groupName = item.endpoint.groupName?.GetCaseFormat(options.Value.Format) ?? string.Empty;
-            if (!grouped.ContainsKey(groupName))
-                grouped[groupName] = [];
-            grouped[groupName].Add(item);
+            var key = string.IsNullOrWhiteSpace(version) ? groupName : $"{version}_{groupName}";
+            if (!grouped.ContainsKey(key))
+                grouped[key] = [];
+            grouped[key].Add(item);
         });
 
         // Phase 3: One MapGroup per unique group name
@@ -80,9 +88,13 @@ internal static class SharkEndPointExtension
                 continue;
             }
 
-            var basePath = string.IsNullOrWhiteSpace(groupName)
-                ? first.apiPrefix
-                : $"{first.apiPrefix}/{groupName}";
+            var version = first.version?.GetCaseFormat(options.Value.Format);
+            var basePath = first.apiPrefix;
+            if (!string.IsNullOrWhiteSpace(version))
+                basePath = $"{basePath}/{version}";
+            var groupNameForUrl = first.groupName?.GetCaseFormat(options.Value.Format) ?? string.Empty;
+            if (!string.IsNullOrWhiteSpace(groupNameForUrl))
+                basePath = $"{basePath}/{groupNameForUrl}";
 
             var group = app.MapGroup(basePath).WithDisplayName(groupName);
 
@@ -97,7 +109,7 @@ internal static class SharkEndPointExtension
             var tags = ResolveGroupTags(endpoints, groupName);
 
             // Auto-Tags + OperationId via Add() convention (works in JIT and AOT)
-            var capturedGroupName = groupName;
+            var capturedGroupName = !string.IsNullOrWhiteSpace(version) ? $"{version}_{groupName}" : groupName;
             var capturedBasePath = basePath;
             var capturedTags = tags;
             ((IEndpointConventionBuilder)group).Add(builder =>
@@ -204,6 +216,12 @@ internal static class SharkEndPointExtension
         {
             instance.groupName = endpointGroupAttr.Name;
             instance.addPrefix = !string.IsNullOrWhiteSpace(apiPrefix);
+        }
+
+        var versionAttr = shark.GetType().GetCustomAttribute<SharkVersionAttribute>();
+        if (versionAttr != null)
+        {
+            instance.version = versionAttr.Version;
         }
 
         instance.apiPrefix = apiPrefix;


### PR DESCRIPTION
- [SharkVersion("v1")] injects version into URL prefix: /api/v1/{group}/{route}
- Grouping key includes version to keep versioned/non-versioned groups separate
- Version included in auto-generated OperationId for uniqueness
- NativeTest examples: VersionedV1Endpoint, VersionedV2Endpoint
- 3 new tests: versioned URL, versioned+grouped URL, OpenAPI paths
- EN + ZH docs updated in docs repo